### PR TITLE
33 front adjust asidemenu

### DIFF
--- a/src/components/AsideMenu.tsx
+++ b/src/components/AsideMenu.tsx
@@ -2,22 +2,26 @@ import { Link, NavLink, useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import {
     Menu,
-    ArrowLeft,
     LayoutGrid,
     ClipboardPen,
     ChartNoAxesCombined,
     LogOut,
+    X,
+    ChevronRight,
+    ChevronLeft,
 } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
-
-const rpeIcon = 'src/assets/rpe-logo.png';
 
 export default function AsideMenu() {
     const navigate = useNavigate();
     const { logout } = useAuth();
 
-    const [isNavHovered, setIsNavHovered] = useState(false);
+    const [isNavExpanded, setIsNavExpanded] = useState(true);
     const [isMenuOpened, setIsMenuOpened] = useState(false);
+
+    const toggleNav = () => {
+        setIsNavExpanded(!isNavExpanded);
+    };
 
     const openMenu = () => {
         setIsMenuOpened(true);
@@ -34,6 +38,13 @@ export default function AsideMenu() {
 
     return (
         <>
+            {isMenuOpened && (
+                <div
+                    className="hidden max-lg:block fixed inset-0 bg-black bg-opacity-50 z-[998]"
+                    onClick={closeMenu}
+                />
+            )}
+
             {!isMenuOpened && (
                 <Menu
                     onClick={openMenu}
@@ -43,44 +54,53 @@ export default function AsideMenu() {
                 />
             )}
 
-            {isMenuOpened && (
-                <ArrowLeft
-                    onClick={closeMenu}
-                    className="hidden max-lg:block fixed top-4 left-4 text-secondary-400 cursor-pointer z-[1001]"
-                    size={50}
-                    strokeWidth={2.5}
-                />
-            )}
-
             <aside
                 className={`
-                    absolute bg-white flex flex-col p-4 w-24 h-screen border-r-4 border-neutral-300
-                    transition-all duration-300 ease-in-out overflow-hidden z-[999] overflow-y-auto
-                    ${isNavHovered ? 'w-60' : ''}
-                    max-lg:fixed max-lg:top-0 max-lg:left-0 max-lg:w-full max-lg:h-screen max-lg:bg-white max-lg:border-r-0
-                    ${isMenuOpened ? 'max-lg:flex max-lg:flex-col' : 'max-lg:hidden'}
+                    bg-white flex flex-col p-4 h-screen border-r-4 border-neutral-300 relative
+                    transition-all duration-300 ease-in-out overflow-hidden overflow-y-auto
+                    ${isNavExpanded ? 'w-60' : 'w-24'}
+                    max-lg:fixed max-lg:top-0 max-lg:left-0 max-lg:h-screen max-lg:bg-white max-lg:border-r-0 max-lg:z-[999]
+                    ${isMenuOpened ? 'max-lg:w-full max-lg:flex max-lg:flex-col' : 'max-lg:w-0 max-lg:hidden'}
                 `}
                 style={{
-                    boxShadow: isNavHovered
+                    boxShadow: isNavExpanded
                         ? '0 1px 3px 0 rgba(0, 0, 0, 0.05)'
                         : 'none',
                 }}
             >
+                <button
+                    onClick={toggleNav}
+                    className="hidden lg:flex absolute -right-3 top-1/2 transform -translate-y-1/2 bg-white border-2 border-neutral-300 rounded-full p-1 hover:bg-neutral-100 cursor-pointer transition-colors duration-200 z-10"
+                >
+                    {isNavExpanded ? (
+                        <ChevronLeft size={24} className="text-secondary-400" />
+                    ) : (
+                        <ChevronRight
+                            size={24}
+                            className="text-secondary-400"
+                        />
+                    )}
+                </button>
+                <div className="hidden max-lg:block max-lg:absolute max-lg:top-4 max-lg:left-4">
+                    <X
+                        onClick={closeMenu}
+                        className="text-secondary-400 cursor-pointer"
+                        size={50}
+                        strokeWidth={2.5}
+                    />
+                </div>
+
                 <div className="flex justify-center items-center w-full mb-4">
                     <Link to="/">
                         <img
                             className="w-14 h-14 transition-transform duration-300 mx-auto max-lg:w-32 max-lg:h-32 max-lg:mt-8"
-                            src={rpeIcon}
+                            src="src/assets/rpe-logo.png"
                             alt="Logo"
                         />
                     </Link>
                 </div>
 
-                <nav
-                    className="mt-4 w-full h-full mb-5 flex flex-col justify-start"
-                    onMouseEnter={() => setIsNavHovered(true)}
-                    onMouseLeave={() => setIsNavHovered(false)}
-                >
+                <nav className="mt-4 w-full h-full mb-5 flex flex-col justify-start">
                     <ul className="flex flex-col gap-4 pl-0 w-full max-lg:justify-start max-lg:gap-8 max-lg:mt-8 max-lg:pl-20 max-lg:w-auto">
                         <li className="list-none w-full max-lg:flex max-lg:justify-start max-lg:w-auto">
                             <NavLink
@@ -95,12 +115,12 @@ export default function AsideMenu() {
                             >
                                 <LayoutGrid
                                     size={32}
-                                    className="flex-shrink-0 ml-4 max-lg:w-12 max-lg:h-12 max-lg:ml-0 self-center"
+                                    className="flex-shrink-0 ml-3.5 max-lg:w-12 max-lg:h-12 max-lg:ml-0 self-center"
                                 />
                                 <span
                                     className={`
                                     opacity-0 invisible whitespace-nowrap transition-all duration-200 ease-in-out 
-                                    ${isNavHovered ? 'opacity-100 visible' : ''}
+                                    ${isNavExpanded ? 'opacity-100 visible' : ''}
                                     max-lg:opacity-100 max-lg:visible
                                 `}
                                 >
@@ -122,12 +142,12 @@ export default function AsideMenu() {
                             >
                                 <ClipboardPen
                                     size={32}
-                                    className="flex-shrink-0 ml-4 max-lg:w-12 max-lg:h-12 max-lg:ml-0 self-center"
+                                    className="flex-shrink-0 ml-3.5 max-lg:w-12 max-lg:h-12 max-lg:ml-0 self-center"
                                 />
                                 <span
                                     className={`
                                     opacity-0 invisible whitespace-nowrap transition-all duration-200 ease-in-out
-                                    ${isNavHovered ? 'opacity-100 visible' : ''}
+                                    ${isNavExpanded ? 'opacity-100 visible' : ''}
                                     max-lg:opacity-100 max-lg:visible
                                 `}
                                 >
@@ -149,12 +169,12 @@ export default function AsideMenu() {
                             >
                                 <ChartNoAxesCombined
                                     size={32}
-                                    className="flex-shrink-0 ml-4 max-lg:w-12 max-lg:h-12 max-lg:ml-0 self-center"
+                                    className="flex-shrink-0 ml-3.5 max-lg:w-12 max-lg:h-12 max-lg:ml-0 self-center"
                                 />
                                 <span
                                     className={`
                                     opacity-0 invisible whitespace-nowrap transition-all duration-200 ease-in-out
-                                    ${isNavHovered ? 'opacity-100 visible' : ''}
+                                    ${isNavExpanded ? 'opacity-100 visible' : ''}
                                     max-lg:opacity-100 max-lg:visible
                                 `}
                                 >
@@ -177,7 +197,7 @@ export default function AsideMenu() {
                             <span
                                 className={`
                                 opacity-0 invisible whitespace-nowrap transition-all duration-200 ease-in-out 
-                                ${isNavHovered ? 'opacity-100 visible' : ''}
+                                ${isNavExpanded ? 'opacity-100 visible' : ''}
                                 max-lg:opacity-100 max-lg:visible
                             `}
                             >

--- a/src/components/AsideMenu.tsx
+++ b/src/components/AsideMenu.tsx
@@ -37,7 +37,7 @@ export default function AsideMenu() {
             {!isMenuOpened && (
                 <Menu
                     onClick={openMenu}
-                    className="hidden max-lg:block fixed top-4 left-4 text-[#6b9999] cursor-pointer z-[1000]"
+                    className="hidden max-lg:block fixed top-4 left-4 text-secondary-400 cursor-pointer z-[1000]"
                     size={50}
                     strokeWidth={2.5}
                 />
@@ -46,7 +46,7 @@ export default function AsideMenu() {
             {isMenuOpened && (
                 <ArrowLeft
                     onClick={closeMenu}
-                    className="hidden max-lg:block fixed top-4 left-4 text-[#6b9999] cursor-pointer z-[1001]"
+                    className="hidden max-lg:block fixed top-4 left-4 text-secondary-400 cursor-pointer z-[1001]"
                     size={50}
                     strokeWidth={2.5}
                 />
@@ -54,10 +54,10 @@ export default function AsideMenu() {
 
             <aside
                 className={`
-                    absolute bg-[#fff] flex flex-col p-4 w-24 h-screen border-r-4 border-[#D9D9D9]
+                    absolute bg-white flex flex-col p-4 w-24 h-screen border-r-4 border-neutral-300
                     transition-all duration-300 ease-in-out overflow-hidden z-[999] overflow-y-auto
                     ${isNavHovered ? 'w-60' : ''}
-                    max-lg:fixed max-lg:top-0 max-lg:left-0 max-lg:w-full max-lg:h-screen max-lg:bg-[#fff] max-lg:border-r-0
+                    max-lg:fixed max-lg:top-0 max-lg:left-0 max-lg:w-full max-lg:h-screen max-lg:bg-white max-lg:border-r-0
                     ${isMenuOpened ? 'max-lg:flex max-lg:flex-col' : 'max-lg:hidden'}
                 `}
                 style={{
@@ -88,9 +88,9 @@ export default function AsideMenu() {
                                 onClick={closeMenu}
                                 className={({ isActive }) => `
                                     flex items-center gap-4 no-underline relative 
-                                    transition-all duration-200 ease-in-out hover:text-[#3a7b7d]
+                                    transition-all duration-200 ease-in-out hover:text-secondary-600
                                     max-lg:text-2xl max-lg:gap-4
-                                    ${isActive ? 'text-[#2b5f60]' : 'text-[#6b9999]'}
+                                    ${isActive ? 'text-primary-500' : 'text-secondary-400'}
                                 `}
                             >
                                 <LayoutGrid
@@ -115,9 +115,9 @@ export default function AsideMenu() {
                                 onClick={closeMenu}
                                 className={({ isActive }) => `
                                     flex items-center gap-4 no-underline relative 
-                                    transition-all duration-200 ease-in-out hover:text-[#3a7b7d]
+                                    transition-all duration-200 ease-in-out hover:text-secondary-600
                                     max-lg:text-2xl max-lg:gap-4
-                                    ${isActive ? 'text-[#2b5f60]' : 'text-[#6b9999]'}
+                                    ${isActive ? 'text-primary-500' : 'text-secondary-400'}
                                 `}
                             >
                                 <ClipboardPen
@@ -142,9 +142,9 @@ export default function AsideMenu() {
                                 onClick={closeMenu}
                                 className={({ isActive }) => `
                                     flex items-center gap-4 no-underline relative 
-                                    transition-all duration-200 ease-in-out hover:text-[#3a7b7d]
+                                    transition-all duration-200 ease-in-out hover:text-secondary-600
                                     max-lg:text-2xl max-lg:gap-4
-                                    ${isActive ? 'text-[#2b5f60]' : 'text-[#6b9999]'}
+                                    ${isActive ? 'text-primary-500' : 'text-secondary-400'}
                                 `}
                             >
                                 <ChartNoAxesCombined
@@ -167,7 +167,7 @@ export default function AsideMenu() {
                     <div className="flex w-full mt-auto max-lg:mb-4 max-lg:justify-center">
                         <div
                             onClick={handleLogout}
-                            className="flex items-center gap-4 cursor-pointer ml-4 text-[#6b9999] hover:text-[#3a7b7d] transition-colors duration-200 max-lg:text-2xl max-lg:gap-4 max-lg:ml-0"
+                            className="flex items-center gap-4 cursor-pointer ml-4 text-secondary-400 hover:text-secondary-600 transition-colors duration-200 max-lg:text-2xl max-lg:gap-4 max-lg:ml-0"
                         >
                             <LogOut
                                 size={32}

--- a/src/index.css
+++ b/src/index.css
@@ -11,6 +11,20 @@
     --color-primary-700: #163a3d;
     --color-primary-800: #0f2d30;
     --color-primary-900: #0a2224;
+
+    --color-secondary-400: #6b9999;
+    --color-secondary-600: #3a7b7d;
+
+    --color-neutral-100: #f5f5f5;
+    --color-neutral-200: #e5e5e5;
+    --color-neutral-300: #d4d4d4;
+    --color-neutral-400: #a3a3a3;
+    --color-neutral-500: #8b949e;
+    --color-neutral-700: #374151;
+    --color-neutral-800: #21262d;
+
+    --color-error-500: #da3633;
+    --color-error-600: #b91c1c;
 }
 
 /* Gradiente para texto - com melhor rendering */

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -5,7 +5,7 @@ export function DefaultLayout() {
     return (
         <div className="flex h-screen">
             <AsideMenu />
-            <div className="flex-1 h-full overflow-y-auto max-lg:w-full">
+            <div className="flex-1 h-full overflow-y-auto max-lg:w-full max-lg:mt-15">
                 <Outlet />
             </div>
         </div>

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -3,9 +3,9 @@ import AsideMenu from '../components/AsideMenu';
 
 export function DefaultLayout() {
     return (
-        <div className="relative h-screen max-lg:flex-col">
+        <div className="flex h-screen">
             <AsideMenu />
-            <div className="h-full overflow-y-auto ml-24 max-lg:ml-0">
+            <div className="flex-1 h-full overflow-y-auto max-lg:w-full">
                 <Outlet />
             </div>
         </div>


### PR DESCRIPTION
O AsideMenu foi refatorado para utilizar cores contidas no index.css, algumas não estavam lá então eu tive que colocar.
Também adicionei a funcionalidade de abrir e fechar a Bar com um botão, para o usuário ter mais liberdade.
Pequeno ajuste no layout na versão mobile para encaixar melhor na tela do smartphone.